### PR TITLE
Separating crontab metric items

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ WORKDIR aws-scripts-mon
 ADD ./entry.sh /entry.sh
 RUN chmod +x /entry.sh
 ENTRYPOINT ["/entry.sh"]
-CMD ["--mem-util", "--mem-used", "--mem-avail", "--disk-space-util", "--disk-space-avail", "--disk-space-used", "--disk-path=/etc/hosts"]
+CMD ["-m", "-d", "/etc/hosts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.5
 
 ENV AWS_ACCESS_KEY_ID=""
 ENV AWS_SECRET_ACCESS_KEY=""
@@ -16,7 +16,9 @@ RUN update-ca-certificates
 
 RUN wget http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip && \
   unzip CloudWatchMonitoringScripts-1.2.1.zip && \
-  rm CloudWatchMonitoringScripts-1.2.1.zip
+  rm CloudWatchMonitoringScripts-1.2.1.zip && \
+  /bin/sed -i 's#/proc/meminfo#/host/proc/meminfo#g' /aws-scripts-mon/mon-put-instance-data.pl
+
 WORKDIR aws-scripts-mon
 
 ADD ./entry.sh /entry.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,4 @@ WORKDIR aws-scripts-mon
 ADD ./entry.sh /entry.sh
 RUN chmod +x /entry.sh
 ENTRYPOINT ["/entry.sh"]
+CMD ["--mem-util", "--mem-used", "--mem-avail", "--disk-space-util", "--disk-space-avail", "--disk-space-used", "--disk-path=/etc/hosts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV AWS_ACCESS_KEY_ID=""
 ENV AWS_SECRET_ACCESS_KEY=""
 ENV AWS_IAM_ROLE=""
 
-RUN apk add --update wget unzip bash perl-datetime perl-libwww
+RUN apk add --update coreutils wget unzip bash perl-datetime perl-libwww
 RUN rm -rf /var/cache/apk/*
 
 RUN wget http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,17 @@
-FROM ubuntu
-MAINTAINER https://github.com/ariabov
+FROM alpine:latest
 
-# Install monitoring scripts
+ENV AWS_ACCESS_KEY_ID=""
+ENV AWS_SECRET_ACCESS_KEY=""
+ENV AWS_IAM_ROLE=""
 
-RUN apt-get update && \
-  apt-get install -y unzip wget libwww-perl libdatetime-perl && \
-  rm -rf /tmp/* /var/tmp/*
+RUN apk add --update wget unzip bash perl-datetime perl-libwww
+RUN rm -rf /var/cache/apk/*
 
 RUN wget http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip && \
   unzip CloudWatchMonitoringScripts-1.2.1.zip && \
   rm CloudWatchMonitoringScripts-1.2.1.zip
-
 WORKDIR aws-scripts-mon
 
-COPY awscreds.template awscreds.template
-
-# Setup cron
-
-ADD crontab /etc/crontab
-RUN crontab /etc/crontab
-
-# Log file for debugging
-
-RUN touch /var/log/cron.log
-RUN chmod 0644 /var/log/cron.log
-
-ENTRYPOINT cron -f
+ADD ./entry.sh /entry.sh
+RUN chmod +x /entry.sh
+ENTRYPOINT ["/entry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,15 @@ ENV AWS_ACCESS_KEY_ID=""
 ENV AWS_SECRET_ACCESS_KEY=""
 ENV AWS_IAM_ROLE=""
 
-RUN apk add --update coreutils wget unzip bash perl-datetime perl-libwww
+RUN apk add --update \
+  coreutils \
+  wget \
+  unzip \
+  bash \
+  ca-certificates \
+  perl-datetime perl-libwww perl-lwp-protocol-https
 RUN rm -rf /var/cache/apk/*
+RUN update-ca-certificates
 
 RUN wget http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip && \
   unzip CloudWatchMonitoringScripts-1.2.1.zip && \

--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@ This Docker container contains Amazon EC2 scripts to simplify reporting addition
 
 ## Running it
 
-Use [CloudWatch monitoring scripts options](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/mon-scripts.html#mon-scripts-using) with the container. Run it in `--privileged` mode.
+Run it in `--privileged` mode.
+
+Options:
+- `-d disk_path` - report `disk_path` disk usage, mat be used multiple times
+- `-s` - report swap usage
+- `-m` - report memory usage
 
 ```
-docker run --privileged deadroot/docker-cloudwatch-monitoring --mem-util --mem-used --mem-avail --disk-space-util --disk-space-avail --disk-space-used --disk-path=/etc/hosts
+docker run --privileged deadroot/docker-cloudwatch-monitoring -m -s -d /etc/hosts -d /mnt/a
 ```
 
 If you have correct IAM role associated with the instance, it will work without explicit credentials specification. See [Configuration](#Configuration) section for the ways to specify credentials.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,41 @@
 
 This Docker container contains Amazon EC2 scripts to simplify reporting additional EC2 instance information to Cloudwatch. These Perl scripts comprise a fully functional examples that reports memory, swap, and disk space utilization metrics for a Linux instance. You can learn more about the scripts [here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/mon-scripts.html).
 
-## Getting started
+## Running it
 
-1. Create `awscreds.template` with your IAM credentials. You can jumpstart the process by copying and modifying the example file with `cp awscreds.template.example awscreds.template`. For more information regarding creating new IAM role or modifying existing IAM role for your EC2 instance go [here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/mon-scripts.html#mon-scripts-getstarted).
+Build and run it. If you have correct IAM role associated with the instance, it will start working immediately.
 
-2. Create `crontab` to specify what metrics and when you would like reported to CloudWatch. Again, you can speed up development with copying and modifying the example file with `cp crontab.example crontab`. The example cron task reports instance memory and disk usage to CloudWatch every minute. To find the list of all options and what they mean, refer to the official documentation [here](http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/mon-scripts.html#mon-scripts-using). While modifying the options per your requirements, make sure to keep the following in mind:
+See [Configuration](#Configuration) section for the ways to specify credentials.
 
-Unless you move the AWS credential file, the following path should remain the same
+## Configuration
+
+You can specify credentials in the following ways:
+
+### IAM role
+
+IAM role is automatically taken from instance's metadata. Role may be also put into `AWS_IAM_ROLE` variable.
+
+Instance's IAM role should have the following permissions:
+
+- `cloudwatch:PutMetricData`
+- `cloudwatch:GetMetricStatistics`
+- `cloudwatch:ListMetrics`
+- `ec2:DescribeTags`
+
+### Credentials file
+
+Create credentials file with the following content:
 
 ```
---aws-credential-file=/aws-scripts-mon/awscreds.template
+AWSAccessKeyId=YourAccessKeyID
+AWSSecretKey=YourSecretAccessKey
 ```
 
-Correct `disk-path` is required to successfully report disk usage. For simpler configuration, `/etc/hosts` should suffice but feel free to double check if you see any issues.
+Add it to the container to path `/awscreds`: `docker run -v ./aws_creds_file.txt:/awscreds`
 
-## Debugging
+### Environment
 
-If you are encountering any issues with reporting EC2 metrics in production, you may try the included debugging `crontab` file. Copy and modify the debugging example file with `cp crontab.example-debugging crontab`. The two key differences is that the output of cron job is verbose and written to `/var/log/cron.log` file.
+Use the following env. variables for credentials:
+
+1. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+2. `AWS_IAM_ROLE` - IAM role name, used only if `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY` not specified/empty.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Docker container contains Amazon EC2 scripts to simplify reporting addition
 
 ## Running it
 
-Run it in `--privileged` mode.
+Run with host `/proc/` mounted readonly to `/host/proc/`
 
 Options:
 - `-d disk_path` - report `disk_path` disk usage, mat be used multiple times
@@ -12,7 +12,7 @@ Options:
 - `-m` - report memory usage
 
 ```
-docker run --privileged deadroot/docker-cloudwatch-monitoring -m -s -d /etc/hosts -d /mnt/a
+docker run -v /proc/:/host/proc/:ro -v /media:/mnt/a:ro unifio/cloudwatch-monitoring -m -s -d /etc/hosts -d /mnt/a
 ```
 
 If you have correct IAM role associated with the instance, it will work without explicit credentials specification. See [Configuration](#Configuration) section for the ways to specify credentials.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Docker container contains Amazon EC2 scripts to simplify reporting addition
 
 ## Running it
 
-Build and run it. If you have correct IAM role associated with the instance, it will start working immediately.
+Build and run it in `--privileged` mode. If you have correct IAM role associated with the instance, it will start working immediately.
 
 See [Configuration](#Configuration) section for the ways to specify credentials.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ AWSSecretKey=YourSecretAccessKey
 Add it to the container to path `/awscreds`: `docker run -v ./aws_creds_file.txt:/awscreds ...`
 
 ### Environment
+Use the following env. Variable to set the crontab timeframe.
+
+1. `CWM_CRON_TIME` ie `CWM_CRON_TIME="*/5 * * * *"` the default is `CWM_CRON_TIME="* * * * *"`
 
 Use the following env. variables for credentials:
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ This Docker container contains Amazon EC2 scripts to simplify reporting addition
 
 ## Running it
 
-Build and run it in `--privileged` mode. If you have correct IAM role associated with the instance, it will start working immediately.
+Use [CloudWatch monitoring scripts options](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/mon-scripts.html#mon-scripts-using) with the container. Run it in `--privileged` mode.
 
-See [Configuration](#Configuration) section for the ways to specify credentials.
+```
+docker run --privileged deadroot/docker-cloudwatch-monitoring --mem-util --mem-used --mem-avail --disk-space-util --disk-space-avail --disk-space-used --disk-path=/etc/hosts
+```
+
+If you have correct IAM role associated with the instance, it will work without explicit credentials specification. See [Configuration](#Configuration) section for the ways to specify credentials.
 
 ## Configuration
 
@@ -32,7 +36,7 @@ AWSAccessKeyId=YourAccessKeyID
 AWSSecretKey=YourSecretAccessKey
 ```
 
-Add it to the container to path `/awscreds`: `docker run -v ./aws_creds_file.txt:/awscreds`
+Add it to the container to path `/awscreds`: `docker run -v ./aws_creds_file.txt:/awscreds ...`
 
 ### Environment
 

--- a/awscreds.template.example
+++ b/awscreds.template.example
@@ -1,2 +1,0 @@
-AWSAccessKeyId=ACCESS_KEY_ID
-AWSSecretKey=SECRET_KEY

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,30 @@
+machine:
+  environment:
+    CW_SCRIPTS_VERSION: 1.2.1
+    DOCKER_IMAGE: 'unifio/cloudwatch-monitoring'
+  services:
+    - docker
+
+dependencies:
+  cache_directories:
+    - "~/docker"
+  override:
+    - docker info
+    - if [[ -e ~/docker/image.tar ]]; then docker load --input ~/docker/image.tar; fi
+    - docker build --rm=false -t ${DOCKER_IMAGE} .
+    - mkdir -p ~/docker
+    - docker save ${DOCKER_IMAGE} > ~/docker/image.tar
+
+test:
+  override:
+    - docker run --entrypoint=perl ${DOCKER_IMAGE} --version
+    - docker run --entrypoint=./mon-put-instance-data.pl ${DOCKER_IMAGE} --version
+    - docker run --entrypoint=./mon-get-instance-stats.pl ${DOCKER_IMAGE} --version
+
+deployment:
+  hub:
+    branch: master
+    commands:
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker tag -f `docker images | grep -E "${DOCKER_IMAGE}" | awk '{print $3}'` ${DOCKER_IMAGE}:${CW_SCRIPTS_VERSION}.${CIRCLE_BUILD_NUM}
+      - docker push ${DOCKER_IMAGE}

--- a/crontab.example
+++ b/crontab.example
@@ -1,1 +1,0 @@
-* * * * * /aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-path=/etc/hosts --disk-space-util --disk-space-avail --disk-space-used --from-cron --aws-credential-file=/aws-scripts-mon/awscreds.template

--- a/crontab.example-debugging
+++ b/crontab.example-debugging
@@ -1,1 +1,0 @@
-* * * * * /aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-path=/etc/hosts --disk-space-util --disk-space-avail --disk-space-used --verbose --aws-credential-file=/aws-scripts-mon/awscreds.template > /var/log/cron.log 2>&1

--- a/entry.sh
+++ b/entry.sh
@@ -13,6 +13,26 @@ elif [ "${AWS_IAM_ROLE}" ]; then
   echo "Fonnd IAM role"
 fi
 
-echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} $@" > /etc/crontab
+echo -n '' > /etc/crontab
+while getopts ':msd:' opt; do
+  case "$opt" in
+    m)
+      echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --mem-util --mem-used --mem-avail" >> /etc/crontab
+    ;;
+    d)
+      echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --disk-path=${OPTARG} --disk-space-util --disk-space-avail --disk-space-used" >> /etc/crontab
+    ;;
+    s)
+      echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --swap-util --swap-used" >> /etc/crontab
+    ;;
+    :)
+      echo "Need parameter for -${OPTARG}"
+    ;;
+    ?)
+      echo "Unsupported option -${OPTARG}"
+    ;;
+  esac
+done
+
 crontab /etc/crontab
 crond -f

--- a/entry.sh
+++ b/entry.sh
@@ -20,9 +20,6 @@ while getopts ':msd:' opt; do
       echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --mem-util --mem-used --mem-avail" >> /etc/crontab
     ;;
     d)
-      mpath=`echo "$OPTARG" | cut -d ':' -f 1`
-      dpath=`echo "$OPTARG" | cut -d ':' -f 2`
-      [ "$dpath" ] && mkdir -p "$mpath" && mount -t auto -o ro,noatime "$dpath" "$mpath"
       echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --disk-path=${OPTARG} --disk-space-util --disk-space-avail --disk-space-used" >> /etc/crontab
     ;;
     s)

--- a/entry.sh
+++ b/entry.sh
@@ -20,6 +20,9 @@ while getopts ':msd:' opt; do
       echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --mem-util --mem-used --mem-avail" >> /etc/crontab
     ;;
     d)
+      mpath=`echo "$OPTARG" | cut -d ':' -f 1`
+      dpath=`echo "$OPTARG" | cut -d ':' -f 2`
+      [ "$dpath" ] && mkdir -p "$mpath" && mount -t auto -o ro,noatime "$dpath" "$mpath"
       echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --disk-path=${OPTARG} --disk-space-util --disk-space-avail --disk-space-used" >> /etc/crontab
     ;;
     s)

--- a/entry.sh
+++ b/entry.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo -n "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --from-cron --mem-util --mem-used --mem-avail --disk-path=/etc/hosts --disk-space-util --disk-space-avail --disk-space-used --auto-scaling" > /etc/crontab
+echo -n "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-path=/etc/hosts --disk-space-util --disk-space-avail --disk-space-used --auto-scaling" > /etc/crontab
 
 # By default script gets creds automatically, but you can specify IAM role or creds
 if [ -f "/awscreds" ] && [ "`cat "/awscreds" | grep 'AWSAccessKeyId'`" ] && [ "`cat "/awscreds" | grep 'AWSSecretKey'`" ]; then

--- a/entry.sh
+++ b/entry.sh
@@ -1,20 +1,18 @@
 #!/bin/bash
 
-echo -n "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --mem-util --mem-used --mem-avail --disk-path=/etc/hosts --disk-space-util --disk-space-avail --disk-space-used --auto-scaling" > /etc/crontab
-
+_CRED_OPT=''
 # By default script gets creds automatically, but you can specify IAM role or creds
 if [ -f "/awscreds" ] && [ "`cat "/awscreds" | grep 'AWSAccessKeyId'`" ] && [ "`cat "/awscreds" | grep 'AWSSecretKey'`" ]; then
-  echo " --aws-credential-file=/awscreds" >> /etc/crontab
+  _CRED_OPT="--aws-credential-file=/awscreds"
   echo "Found credentials file, skipping load"
 elif [ "${AWS_ACCESS_KEY_ID}" ] && [ "${AWS_SECRET_ACCESS_KEY}" ]; then
-  echo " --aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-key=${AWS_SECRET_ACCESS_KEY}" >> /etc/crontab
+  _CRED_OPT="--aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-key=${AWS_SECRET_ACCESS_KEY}" >> /etc/crontab
   echo "Found and substituted credentials from ENV"
 elif [ "${AWS_IAM_ROLE}" ]; then
-  echo " --aws-iam-role=${AWS_IAM_ROLE}" >> /etc/crontab
+  _CRED_OPT="--aws-iam-role=${AWS_IAM_ROLE}" >> /etc/crontab
   echo "Fonnd IAM role"
 fi
 
+echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} $@" > /etc/crontab
 crontab /etc/crontab
-
-# Run cron
 crond -f

--- a/entry.sh
+++ b/entry.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo -n "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --from-cron --mem-util --mem-used --mem-avail --disk-path=/etc/hosts --disk-space-util --disk-space-avail --disk-space-used --auto-scaling" > /etc/crontab
+
+# By default script gets creds automatically, but you can specify IAM role or creds
+if [ -f "/awscreds" ] && [ "`cat "/awscreds" | grep 'AWSAccessKeyId'`" ] && [ "`cat "/awscreds" | grep 'AWSSecretKey'`" ]; then
+  echo " --aws-credential-file=/awscreds" >> /etc/crontab
+  echo "Found credentials file, skipping load"
+elif [ "${AWS_ACCESS_KEY_ID}" ] && [ "${AWS_SECRET_ACCESS_KEY}" ]; then
+  echo " --aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-key=${AWS_SECRET_ACCESS_KEY}" >> /etc/crontab
+  echo "Found and substituted credentials from ENV"
+elif [ "${AWS_IAM_ROLE}" ]; then
+  echo " --aws-iam-role=${AWS_IAM_ROLE}" >> /etc/crontab
+  echo "Fonnd IAM role"
+fi
+
+crontab /etc/crontab
+
+# Run cron
+crond -f

--- a/entry.sh
+++ b/entry.sh
@@ -2,37 +2,91 @@
 
 _CRED_OPT=''
 # By default script gets creds automatically, but you can specify IAM role or creds
-if [ -f "/awscreds" ] && [ "`cat "/awscreds" | grep 'AWSAccessKeyId'`" ] && [ "`cat "/awscreds" | grep 'AWSSecretKey'`" ]; then
+if [ -f "/awscreds" ] && [ "$(grep 'AWSAccessKeyId' /awscreds)" ]  && [ "$(grep 'AWSSecretKey' /awscreds)" ]; then
   _CRED_OPT="--aws-credential-file=/awscreds"
   echo "Found credentials file, skipping load"
 elif [ "${AWS_ACCESS_KEY_ID}" ] && [ "${AWS_SECRET_ACCESS_KEY}" ]; then
-  _CRED_OPT="--aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-key=${AWS_SECRET_ACCESS_KEY}" >> /etc/crontab
+  _CRED_OPT="--aws-access-key-id=${AWS_ACCESS_KEY_ID} --aws-secret-key=${AWS_SECRET_ACCESS_KEY}"
   echo "Found and substituted credentials from ENV"
 elif [ "${AWS_IAM_ROLE}" ]; then
-  _CRED_OPT="--aws-iam-role=${AWS_IAM_ROLE}" >> /etc/crontab
+  _CRED_OPT="--aws-iam-role=${AWS_IAM_ROLE}"
   echo "Fonnd IAM role"
 fi
 
 echo -n '' > /etc/crontab
+
+CRON_OUTPUT_BASE[0]="/aws-scripts-mon/mon-put-instance-data.pl --auto-scaling"
+
+if [ "$_CRED_OPT" ]; then
+  CRON_OUTPUT_BASE+=("${_CRED_OPT}")
+fi
+
+ARGS=()
+
+# Checks if ARGS already contains the given value
+has_arg() {
+  local element
+  for element in "${@:2}"; do
+    [ "${element}" == "${1}" ] && return 0
+  done
+  return 1
+}
+# Adds the given argument if not specified
+add_arg() {
+  local arg="${1}"
+  [ $# -ge 1 ] && local val="${2}"
+  if ! has_arg "${arg}" "${ARGS[@]}"; then
+    ARGS+=("${arg}")
+    [ $# -ge 1 ] && ARGS+=("${val}")
+  fi
+}
+# Adds the given argument duplicates ok.
+add_arg_simple() {
+  local arg="${1}"
+  [ $# -ge 1 ] && local val="${2}"
+  ARGS+=("${arg}")
+  [ $# -ge 1 ] && ARGS+=("${val}")
+}
+
 while getopts ':msd:' opt; do
   case "$opt" in
     m)
-      echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --mem-util --mem-used --mem-avail" >> /etc/crontab
-    ;;
+      add_arg "--mem-util"
+      add_arg "--mem-used"
+      add_arg "--mem-avail"
+      ;;
     d)
-      echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --disk-path=${OPTARG} --disk-space-util --disk-space-avail --disk-space-used" >> /etc/crontab
-    ;;
+      add_arg "--disk-space-util"
+      add_arg "--disk-space-avail"
+      add_arg "--disk-space-used"
+      add_arg_simple "--disk-path=${OPTARG}"
+      ;;
     s)
-      echo "* * * * * /aws-scripts-mon/mon-put-instance-data.pl --auto-scaling ${_CRED_OPT} --swap-util --swap-used" >> /etc/crontab
-    ;;
-    :)
+      add_arg "--swap-util"
+      add_arg "--swap-used"
+      ;;
+    \?)
+      set +x
       echo "Need parameter for -${OPTARG}"
-    ;;
-    ?)
+      ;;
+    :)
+      set +x
       echo "Unsupported option -${OPTARG}"
-    ;;
+      ;;
   esac
 done
+
+# Get rid of processed options from Array
+shift "$((OPTIND-1))"
+# store remaining arguments for future use possibly
+#USER_ARGS=("${@}")
+CRON_OUTPUT_BASE=(${CRON_OUTPUT_BASE[@]} ${ARGS[@]})
+## Check for Cron arg
+if [ "$CWM_CRON_TIME" ];then
+  echo "${CWM_CRON_TIME}" "${CRON_OUTPUT_BASE[@]}" >> /etc/crontab
+else
+  echo "* * * * *" "${CRON_OUTPUT_BASE[@]}" >> /etc/crontab
+fi
 
 crontab /etc/crontab
 crond -f


### PR DESCRIPTION
- Separated the metrics collected to individual crontab entries to avoid exceeding PUT size restrictions for API. 

[Each PutMetricData request is limited to 40 KB in size for HTTP POST requests.](http://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricData.html)